### PR TITLE
[Feature Request]: Event for modify mob spawning position

### DIFF
--- a/src/main/java/net/smileycorp/hordes/common/event/HordeComputeSpawnBasePosEvent.java
+++ b/src/main/java/net/smileycorp/hordes/common/event/HordeComputeSpawnBasePosEvent.java
@@ -1,0 +1,37 @@
+package net.smileycorp.hordes.common.event;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.phys.Vec3;
+import net.smileycorp.hordes.hordeevent.capability.HordeEvent;
+
+public class HordeComputeSpawnBasePosEvent extends HordePlayerEvent {
+
+	protected final Vec3 baseDir;
+	protected final BlockPos firstBasePos;
+	protected BlockPos basePos;
+
+	public HordeComputeSpawnBasePosEvent(ServerPlayer player, HordeEvent horde, Vec3 basedir, BlockPos basepos) {
+		super(player, horde);
+		this.baseDir = basedir;
+		this.firstBasePos = basepos;
+		this.basePos = basepos;
+	}
+
+	public Vec3 getBaseDir() {
+		return baseDir;
+	}
+
+	public BlockPos getFirstBasePos() {
+		return firstBasePos;
+	}
+
+	public BlockPos getBasePos() {
+		return basePos;
+	}
+
+	public void setBasePos(BlockPos basePos) {
+		this.basePos = basePos;
+	}
+
+}

--- a/src/main/java/net/smileycorp/hordes/hordeevent/capability/HordeEvent.java
+++ b/src/main/java/net/smileycorp/hordes/hordeevent/capability/HordeEvent.java
@@ -124,16 +124,16 @@ public class HordeEvent {
 		if (startEvent.isCanceled()) return;
 		count = startEvent.getCount();
 		Vec3 basedir = DirectionUtils.getRandomDirectionVecXZ(rand);
-		BlockPos basepos = DirectionUtils.getClosestLoadedPos(level, player.blockPosition(), basedir, 75, 7, 0);
+		BlockPos basepos = getBasePos(level, basedir, player, true);
 		int i = 0;
 		while (basepos.equals(player.blockPosition())) {
 			basedir = DirectionUtils.getRandomDirectionVecXZ(rand);
-			basepos = DirectionUtils.getClosestLoadedPos(level, player.blockPosition(), basedir, 75, 7, 0);
+			basepos = getBasePos(level, basedir, player, true);
 			if (!spawnData.getSpawnType().canSpawn(level, basepos)) basepos = player.blockPosition();
 			if (i++ >= HordeEventConfig.hordeSpawnChecks.get()) {
 				logInfo("Unable to find unlit pos for horde " + this + " ignoring light level");
 				basedir = DirectionUtils.getRandomDirectionVecXZ(rand);
-				basepos = DirectionUtils.getClosestLoadedPos(level, player.blockPosition(), basedir, 75);
+				basepos = getBasePos(level, basedir, player, false);
 				break;
 			}
 		}
@@ -173,7 +173,20 @@ public class HordeEvent {
 			}
 		}
 	}
-	
+
+	private BlockPos getBasePos(ServerLevel level, Vec3 basedir, ServerPlayer player, boolean checkminlight) {
+		double radius = 75.0D;
+		BlockPos basepos = null;
+		if (checkminlight) {
+			basepos = DirectionUtils.getClosestLoadedPos(level, player.blockPosition(), basedir, radius, 7, 0);
+		} else {
+			basepos = DirectionUtils.getClosestLoadedPos(level, player.blockPosition(), basedir, radius);
+		}
+		HordeComputeSpawnBasePosEvent event = new HordeComputeSpawnBasePosEvent(player, this, basedir, basepos);
+		MinecraftForge.EVENT_BUS.post(event);
+		return event.getBasePos();
+	}
+
 	private Vec3 getSpawnPos(ServerLevel level, Vec3 basepos) {
 		for (int j = 0; j < 5; j++) {
 			double x = basepos.x() + rand.nextInt(10);


### PR DESCRIPTION
Target minecraft version: 1.20.1

If installed both The Hordes with MineColonies,
Horde event's mobs are can be spawn in MineColonies's colony area.

Since it spawns inside the colony, any barriers the player prepares are useless,
And all colonist will immediately be in a state of chaos.

I think that for improved immersion, we need to be able to prevent this kind of thing.
So needs a way to change the mob spawning position.

![image](https://github.com/user-attachments/assets/e7134475-22ec-4c86-9b5e-ee44f91ad2c7)

This pull request is a sample of one way to do that.
Could you please implement the above in The Hordes?

If not, please add some events like this.
Then, I will make a new addon mod about solve this issue.
Without these events, I have no choice but to implement them using Mixins to The Hordes.

I used translator for my poor English.
Thanks.