### PR TITLE
Fix Hostile Zombie Piglins Bug

### DIFF
--- a/src/main/java/net/smileycorp/hordes/infection/InfectionEventHandler.java
+++ b/src/main/java/net/smileycorp/hordes/infection/InfectionEventHandler.java
@@ -9,6 +9,7 @@ import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
 import net.minecraft.world.entity.monster.Zombie;
+import net.minecraft.world.entity.monster.ZombifiedPiglin;
 import net.minecraft.world.entity.monster.ZombieVillager;
 import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.player.Player;
@@ -67,7 +68,11 @@ public class InfectionEventHandler {
 		Entity entity = event.getEntity();
 		if (!(entity instanceof Mob && InfectionConfig.infectionEntitiesAggroConversions.get()) || entity.level().isClientSide) return;
 		if (HordesInfection.canCauseInfection((LivingEntity) entity)) {
-			((Mob) entity).targetSelector.addGoal(3, new NearestAttackableTargetGoal<>((Mob) entity, LivingEntity.class,
+			if (entity instanceof ZombifiedPiglin)
+				((Mob) entity).targetSelector.addGoal(3, new NearestAttackableTargetGoal<>((Mob) entity, LivingEntity.class, 
+						10, true, false, InfectionDataLoader.INSTANCE::canBeInfectedZP));
+			else
+				((Mob) entity).targetSelector.addGoal(3, new NearestAttackableTargetGoal<>((Mob) entity, LivingEntity.class, 
 					10, true, false, InfectionDataLoader.INSTANCE::canBeInfected));
 		}
 	}

--- a/src/main/java/net/smileycorp/hordes/infection/data/InfectionDataLoader.java
+++ b/src/main/java/net/smileycorp/hordes/infection/data/InfectionDataLoader.java
@@ -22,6 +22,7 @@ import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.smileycorp.hordes.common.HordesLogger;
 import net.smileycorp.hordes.common.event.InfectEntityEvent;
+import net.smileycorp.hordes.config.CommonConfigHandler;
 import net.smileycorp.hordes.config.InfectionConfig;
 import net.smileycorp.hordes.infection.HordesInfection;
 import net.smileycorp.hordes.infection.InfectedEffect;
@@ -132,6 +133,13 @@ public class InfectionDataLoader extends SimpleJsonResourceReloadListener {
 
     public boolean canBeInfected(Entity entity) {
         if (entity instanceof Player) return InfectionConfig.infectPlayers.get();
+        if (entity instanceof Villager && InfectionConfig.infectVillagers.get()) return true;
+        if (!(entity instanceof Mob)) return false;
+        return conversionTable.containsKey(entity.getType());
+    }
+    
+    public boolean canBeInfectedZP(Entity entity) {
+        if (entity instanceof Player) return CommonConfigHandler.aggressiveZombiePiglins.get();
         if (entity instanceof Villager && InfectionConfig.infectVillagers.get()) return true;
         if (!(entity instanceof Mob)) return false;
         return conversionTable.containsKey(entity.getType());

--- a/src/main/java/net/smileycorp/hordes/mixin/MixinZombifiedPiglin.java
+++ b/src/main/java/net/smileycorp/hordes/mixin/MixinZombifiedPiglin.java
@@ -6,6 +6,7 @@ import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
 import net.minecraft.world.entity.animal.IronGolem;
 import net.minecraft.world.entity.animal.Turtle;
 import net.minecraft.world.entity.monster.Zombie;
+import net.minecraft.world.entity.NeutralMob;
 import net.minecraft.world.entity.monster.ZombifiedPiglin;
 import net.minecraft.world.entity.npc.AbstractVillager;
 import net.minecraft.world.entity.player.Player;
@@ -18,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ZombifiedPiglin.class)
-public abstract class MixinZombifiedPiglin extends Zombie {
+public abstract class MixinZombifiedPiglin extends Zombie implements NeutralMob{
 
 	protected MixinZombifiedPiglin(Level level) {
 		super(null, level);


### PR DESCRIPTION
Zombie Piglins are now only hostile if the config is enabled.
- Zombie Piglins are now properly implementing NeutralMob
- Zombie Piglins have their own function to test whether they can infect a mob based on the aggression setting