### PR TITLE
Fix horse infection and flee behavior, conversion spawning, and flee AI crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'eclipse'
 apply plugin: 'org.spongepowered.mixin'
 apply plugin: 'java'
 
-version = "1.12.2-1.5.3c"
+version = "1.12.2-1.5.3d-SNAPSHOT"
 group = "net.smileycorp.hordes"
 archivesBaseName = "The-Hordes"
 

--- a/src/main/java/net/smileycorp/hordes/common/ai/EntityAIFleeEntity.java
+++ b/src/main/java/net/smileycorp/hordes/common/ai/EntityAIFleeEntity.java
@@ -67,17 +67,22 @@ public class EntityAIFleeEntity extends EntityAIBase {
 
 	private BlockPos findSafePos() {
 		Vec3d pos = entity.getPositionVector();
-		Vec3d resultDir = new Vec3d(0, 0, 0);
+		Vec3d resultDir = Vec3d.ZERO;
 		for (EntityLivingBase entity : getEntities()) {
 			Vec3d dir = DirectionUtils.getDirectionVecXZ(this.entity, entity);
-			resultDir = new Vec3d((dir.x + resultDir.x)/2, (dir.y + resultDir.y)/2, (dir.z + resultDir.z)/2);
+			resultDir = resultDir.subtract(dir);
 		}
+		if (resultDir.lengthSquared() == 0) return entity.getPosition();
+		resultDir = resultDir.normalize().scale(range);
 		return new BlockPos(pos.add(resultDir));
 	}
 
 	private List<EntityLivingBase> getEntities() {
-		return world.getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(entity.posX - range, entity.posY - range, entity.posZ - range,
-				entity.posX + range, entity.posY + range, entity.posZ + range), predicate);
+        return world.getEntitiesWithinAABB(
+                EntityLivingBase.class,
+                new AxisAlignedBB(entity.posX - range, entity.posY - range, entity.posZ - range,
+                entity.posX + range, entity.posY + range, entity.posZ + range),
+                predicate);
 	}
 
 }

--- a/src/main/java/net/smileycorp/hordes/common/ai/EntityAIHorseFlee.java
+++ b/src/main/java/net/smileycorp/hordes/common/ai/EntityAIHorseFlee.java
@@ -1,17 +1,24 @@
 package net.smileycorp.hordes.common.ai;
 
 import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
 import net.smileycorp.hordes.config.data.infection.InfectionDataLoader;
 
 public class EntityAIHorseFlee extends EntityAIFleeEntity {
 
 	public EntityAIHorseFlee(EntityLiving entity) {
-		super(entity, 2D, 15, InfectionDataLoader.INSTANCE::canCauseInfection);
+		super(entity, 1.2, 15.0, EntityAIHorseFlee::canHorseFlee);
+	}
+
+	private static boolean canHorseFlee(EntityLivingBase target) {
+		boolean loaderReady = InfectionDataLoader.INSTANCE != null;
+        return loaderReady && InfectionDataLoader.INSTANCE.canCauseInfection(target);
 	}
 
 	@Override
 	public boolean shouldExecute() {
-		return super.shouldExecute() && entity.getPassengers().isEmpty();
+		boolean base = super.shouldExecute();
+		return base && entity.getPassengers().isEmpty();
 	}
 
 }

--- a/src/main/java/net/smileycorp/hordes/config/CommonConfigHandler.java
+++ b/src/main/java/net/smileycorp/hordes/config/CommonConfigHandler.java
@@ -28,7 +28,7 @@ public class CommonConfigHandler {
 			aggressiveZombieHorses = config.get("Misc", "aggressiveZombieHorses", true, "Whether zombie horses are aggressive or not.").getBoolean();
 			zombieHorsesBurn = config.get("Misc", "zombieHorsesBurn", false, "Whether zombie horses burn in sunlight").getBoolean();
 			skeletonHorsesBurn = config.get("Misc", "skeletonHorsesBurn", false, "Whether skeleton horses burn in sunlight").getBoolean();
-			zombiesScareHorses = config.get("Misc", "zombiesScareHorses", true, "Whether zombies scare horses").getBoolean();
+			zombiesScareHorses = config.get("Misc", "zombiesScareHorses", true, "Whether zombies scare horses (and donkeys)").getBoolean();
 		} catch(Exception e) {
 		} finally {
 			if (config.hasChanged()) config.save();

--- a/src/main/java/net/smileycorp/hordes/config/InfectionConfig.java
+++ b/src/main/java/net/smileycorp/hordes/config/InfectionConfig.java
@@ -23,11 +23,12 @@ public class InfectionConfig {
         villagerInfectChance = config.get("Infection", "villagerInfectChance", 0.85, "Chance for a villager to get infected, a value of 1 or higher makes it guaranteed").getDouble();
         infectPlayers = config.get("Infection", "infectPlayers", true, "Can players be infected.").getBoolean();
         infectSlowness = config.get("Infection", "infectSlowness", true, "Whether later levels of infected should slightly slow movement speed? ").getBoolean();
-        infectHunger = config.get("Infection", "infectHunger", true, "Whether later levels of infected should depleet hunger quicker? ").getBoolean();
+        infectHunger = config.get("Infection", "infectHunger", true, "Whether later levels of infected should deplete hunger quicker? ").getBoolean();
         playerInfectChance = config.get("Infection", "playerInfectChance", 0.75, "Chance for a player to get infected, a value of 1 or higher makes it guaranteed").getDouble();
         ticksForEffectStage = config.get("Infection", "ticksForEffectStage", 6000, "How long do each of the 4 effect phases last for before the next phase is activated?").getInt();
         infectionSpawnsZombiePlayers = config.get("Infection", "infectionSpawnsZombiePlayers", true, "Do players who die to infection spawn a zombie??").getBoolean();
         effectStageTickReduction = config.get("Infection", "effectStageTickReduction", 0.95, "What factor should the infection potion effect timer be multiplied by for each cured infection? (Resets on death, set to 1 to disable scaling)").getDouble();
+        infectionEntitiesAggroConversions = config.get("Infection", "infectionEntitiesAggroConversions", true, "Should infectious entities be aggressive towards mobs they can infect? (aside from vanilla behavior)").getBoolean();
     }
     
 }

--- a/src/main/java/net/smileycorp/hordes/config/data/infection/InfectionDataLoader.java
+++ b/src/main/java/net/smileycorp/hordes/config/data/infection/InfectionDataLoader.java
@@ -219,7 +219,17 @@ public class InfectionDataLoader {
 
     public boolean convertEntity(EntityLivingBase entity) {
         InfectionConversionEntry entry = conversionTable.get(entity.getClass());
-        if (entry != null) return entry.convertEntity(entity) != null;
+        if (entry != null) {
+            EntityLiving zombie = entry.convertEntity(entity);
+            if (zombie != null) {
+                zombie.setLocationAndAngles(entity.posX, entity.posY, entity.posZ, entity.rotationYaw, entity.rotationPitch);
+                entity.world.spawnEntity(zombie);
+                zombie.renderYawOffset = entity.renderYawOffset;
+                zombie.rotationYawHead = entity.rotationYawHead;
+                return true;
+            }
+            return false;
+        }
         return false;
     }
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "hordes",
   "name": "The Hordes",
   "description": "Horde Invasions and Zombie Infection",
-  "version": "1.5.3c",
+  "version": "1.5.3d-SNAPSHOT",
   "mcversion": "${mcversion}",
   "url": "https://www.curseforge.com/minecraft/mc-mods/the-hordes",
   "updateUrl": "",


### PR DESCRIPTION
This pull request fixes several issues in the infection and conversion systems on Forge 1.12.2.

### Fixes
- Fixed a crash when horses spawn while `zombiesScareHorses=true`
- Fixed horses not fleeing from infectious mobs while `zombiesScareHorses=true`
- Fixed `infectionEntitiesAggroConversions` not being loaded from config
- Fixed converted entities being created but never spawned into the world

### Details

**Horse flee crash**

`EntityAIHorseFlee` previously used a bound method reference:
```
InfectionDataLoader.INSTANCE::canCauseInfection
```
If the infection data loader had not been initialized yet, this caused a constructor-time `NullPointerException`.

This PR replaces the bound method with a null-safe method so the AI can be attached safely.

---

**Horses not fleeing**

`zombiesScareHorses=true` did not cause horses to flee from zombies.

`EntityAIFleeEntity.findSafePos()` incorrectly calculated the new position.

---

**Config loading bug**

`infectionEntitiesAggroConversions` existed in the config file but was never loaded in `InfectionConfig.syncConfig()`.

This prevented infectious mobs from receiving `EntityAINearestAttackableConversion`.

---

**Conversion spawning**

The generic infection conversion path created replacement entities but never spawned them into the world.

Converted entities are now spawned at the dead entity's position with matching orientation.

---

### Testing

Tested on Forge 1.12.2:

- Horses spawn without crashing
- Horses flee from infectious mobs when enabled
- Infectious mobs attack infectable mobs when enabled
- Horses convert to zombie horses on death when configured