### PR TITLE
Fix player zombies crashing multiplayer clients

### DIFF
--- a/src/main/java/net/smileycorp/hordes/common/entities/DrownedPlayer.java
+++ b/src/main/java/net/smileycorp/hordes/common/entities/DrownedPlayer.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.contents.PlainTextContents;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.Difficulty;
@@ -81,13 +82,19 @@ public class DrownedPlayer extends Drowned implements PlayerZombie<DrownedPlayer
 	
 	@Override
 	public void setPlayer(String username) {
-		Optional<GameProfile> optional = ServerLifecycleHooks.getCurrentServer().getProfileCache().get(username);
+		if (level().isClientSide) return;
+		MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+		if (server == null) return;
+		Optional<GameProfile> optional = server.getProfileCache().get(username);
 		if (optional.isPresent()) setPlayer(optional.get());
 	}
 	
 	@Override
 	public void setPlayer(UUID uuid) {
-		Optional<GameProfile> optional = ServerLifecycleHooks.getCurrentServer().getProfileCache().get(uuid);
+		if (level().isClientSide) return;
+		MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+		if (server == null) return;
+		Optional<GameProfile> optional = server.getProfileCache().get(uuid);
 		if (optional.isPresent()) setPlayer(optional.get());
 	}
 	

--- a/src/main/java/net/smileycorp/hordes/common/entities/HuskPlayer.java
+++ b/src/main/java/net/smileycorp/hordes/common/entities/HuskPlayer.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.contents.PlainTextContents;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.Difficulty;
@@ -83,13 +84,19 @@ public class HuskPlayer extends Husk implements PlayerZombie<HuskPlayer> {
 	
 	@Override
 	public void setPlayer(String username) {
-		Optional<GameProfile> optional = ServerLifecycleHooks.getCurrentServer().getProfileCache().get(username);
+		if (level().isClientSide) return;
+		MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+		if (server == null) return;
+		Optional<GameProfile> optional = server.getProfileCache().get(username);
 		if (optional.isPresent()) setPlayer(optional.get());
 	}
 	
 	@Override
 	public void setPlayer(UUID uuid) {
-		Optional<GameProfile> optional = ServerLifecycleHooks.getCurrentServer().getProfileCache().get(uuid);
+		if (level().isClientSide) return;
+		MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+		if (server == null) return;
+		Optional<GameProfile> optional = server.getProfileCache().get(uuid);
 		if (optional.isPresent()) setPlayer(optional.get());
 	}
 	

--- a/src/main/java/net/smileycorp/hordes/common/entities/ZombiePlayer.java
+++ b/src/main/java/net/smileycorp/hordes/common/entities/ZombiePlayer.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.contents.PlainTextContents;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.Difficulty;
@@ -82,13 +83,19 @@ public class ZombiePlayer extends Zombie implements PlayerZombie<ZombiePlayer> {
 	
 	@Override
 	public void setPlayer(String username) {
-		Optional<GameProfile> optional = ServerLifecycleHooks.getCurrentServer().getProfileCache().get(username);
+		if (level().isClientSide) return;
+		MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+		if (server == null) return;
+		Optional<GameProfile> optional = server.getProfileCache().get(username);
 		if (optional.isPresent()) setPlayer(optional.get());
 	}
 	
 	@Override
 	public void setPlayer(UUID uuid) {
-		Optional<GameProfile> optional = ServerLifecycleHooks.getCurrentServer().getProfileCache().get(uuid);
+		if (level().isClientSide) return;
+		MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+		if (server == null) return;
+		Optional<GameProfile> optional = server.getProfileCache().get(uuid);
 		if (optional.isPresent()) setPlayer(optional.get());
 	}
 	


### PR DESCRIPTION
Fixes a crash that disconnects players when a player zombie appears on a multiplayer server. The fix applies to zombie, husk, and drowned player variants. Server behavior is unchanged.